### PR TITLE
Ändere das Build-Skript in package.json von "rollup -c" zu "node buil…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "my-typewriter-line",
   "version": "1.0.1",
-"description": "Obsidian plugin with dynamic CSS and settings",
+  "description": "Obsidian plugin with dynamic CSS and settings",
   "main": "main.js",
   "scripts": {
-    "build": "rollup -c"
+    "build": "node build.js"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",


### PR DESCRIPTION
This pull request updates the build process for the project by changing the `build` script in `package.json` to use a custom Node.js build script instead of Rollup.

- Build process update:
  * Changed the `build` script in `package.json` to run `node build.js` instead of `rollup -c`, indicating a switch to a custom build process.…d.js"